### PR TITLE
Chaining transforms

### DIFF
--- a/src/transform.spec.ts
+++ b/src/transform.spec.ts
@@ -1,5 +1,6 @@
 import transform from "./transform";
 import { transformFile } from "html-validate/test-utils";
+import { Source } from "html-validate";
 
 test("should extract html blocks from markdown files", () => {
     const result = transformFile(transform, "./test/markdown.md");
@@ -19,4 +20,13 @@ test("should extract html blocks from markdown files", () => {
 test("should extract html blocks from markdown files with multi line html", () => {
     const result = transformFile(transform, "./test/multiline.md");
     expect(result).toHaveLength(1);
+});
+
+test("should chain transformations", () => {
+    const chain = jest.fn((source: Source) => [source]);
+    transformFile(transform, "./test/multiline.md", chain);
+    expect(chain).toHaveBeenCalledWith(
+        expect.anything(),
+        "./test/multiline.md:html"
+    );
 });

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -20,17 +20,17 @@ function findLocation(
 }
 
 function* markdownTransform(source: Source): Iterable<Source> {
-    const htmlBlock = /^(```html)([^]*?)^```/gm;
+    const htmlBlock = /^(```(html|[jt]sx?))([^]*?)^```/gm;
 
     let match;
     while ((match = htmlBlock.exec(source.data)) !== null) {
-        const [, preamble, data] = match;
+        const [, preamble, lang, data] = match;
         const [line, column] = findLocation(
             source.data,
             match.index,
             preamble.length
         );
-        yield {
+        const cur: Source = {
             data,
             offset: match.index + (source.offset || 0) + preamble.length,
             filename: source.filename,
@@ -38,6 +38,7 @@ function* markdownTransform(source: Source): Iterable<Source> {
             column,
             originalData: source.originalData || source.data,
         };
+        yield* this.chain(cur, `${source.filename}:${lang}`);
     }
 }
 


### PR DESCRIPTION
Allows transforming more languages:

* html
* js
* jsx
* ts
* tsx

All languages will be chained to other transformers, e.g. applying transformations from `html-validate-vue`.

Language aliases such as `typescript` is not supported (yet).