### PR TITLE
feat!: require node 14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,12 +8,12 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [12.x, 14.x, 16.x]
+                node-version: [14.x, 16.x, 18.x]
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v1
+              uses: actions/setup-node@v3
               with:
                   node-version: ${{ matrix.node-version }}
             - run: npm ci
@@ -31,9 +31,9 @@ jobs:
                 html-validate: [2.x, 3.x, 4.x, 5.x, 6.x, 7.x]
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - name: Use Node.js 16
-              uses: actions/setup-node@v1
+              uses: actions/setup-node@v3
               with:
                   node-version: 16
             - name: Build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# `html-validate-markdown` CHANGELOG
+
+## `3.0.0` (2022-05-09)
+
+-   BREAKING CHANGE: require Node 14
+-   support `html-validate` v7

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@sidvind/build-scripts": "^1.0.0",
         "@types/estree": "0.0.45",
         "@types/jest": "^27.4.0",
-        "@types/node": "^11.15.27",
+        "@types/node": "^14.18.16",
         "@typescript-eslint/eslint-plugin": "^4.3.0",
         "@typescript-eslint/parser": "^4.3.0",
         "eslint": "^7.10.0",
@@ -29,7 +29,7 @@
         "typescript": "^4.3.4"
       },
       "engines": {
-        "node": ">= 12.0"
+        "node": ">= 14.0"
       },
       "peerDependencies": {
         "html-validate": "^2.17 || ^3 || ^4 || ^5 || ^6 || ^7"
@@ -1753,9 +1753,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "11.15.27",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.15.27.tgz",
-      "integrity": "sha512-LbLwyGC/ukDV0EbHFP1OCfs2V5h3vUS8ZXJJjS2L5YYg8rNkJe6Tl/yv+L+g94sbHllyXUCfUCn5+sZLBegvyw==",
+      "version": "14.18.16",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.16.tgz",
+      "integrity": "sha512-X3bUMdK/VmvrWdoTkz+VCn6nwKwrKCFTHtqwBIaQJNx4RUIBBUFXM00bqPz/DsDd+Icjmzm6/tyYZzeGVqb6/Q==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -12415,9 +12415,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "11.15.27",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.15.27.tgz",
-      "integrity": "sha512-LbLwyGC/ukDV0EbHFP1OCfs2V5h3vUS8ZXJJjS2L5YYg8rNkJe6Tl/yv+L+g94sbHllyXUCfUCn5+sZLBegvyw==",
+      "version": "14.18.16",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.16.tgz",
+      "integrity": "sha512-X3bUMdK/VmvrWdoTkz+VCn6nwKwrKCFTHtqwBIaQJNx4RUIBBUFXM00bqPz/DsDd+Icjmzm6/tyYZzeGVqb6/Q==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@sidvind/build-scripts": "^1.0.0",
     "@types/estree": "0.0.45",
     "@types/jest": "^27.4.0",
-    "@types/node": "^11.15.27",
+    "@types/node": "^14.18.16",
     "@typescript-eslint/eslint-plugin": "^4.3.0",
     "@typescript-eslint/parser": "^4.3.0",
     "eslint": "^7.10.0",
@@ -73,6 +73,6 @@
     }
   },
   "engines": {
-    "node": ">= 12.0"
+    "node": ">= 14.0"
   }
 }


### PR DESCRIPTION
`html-validate` requires node 14 so might as well bump it here as well. Node 12 is EOL.